### PR TITLE
Add PHPCS to dev dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,15 @@
 	],
   "require": {
       "composer/installers": "~1.0"
-  }
+  },
+	"require-dev": {
+		"automattic/vipwpcs": "^2.0",
+		"squizlabs/php_codesniffer": "^3.4",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+	},
+	"scripts": {
+		"install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+		"lint": "vendor/bin/phpcs .",
+		"lint-fix": "vendor/bin/phpcbf ."
+	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="VIP Go Indicator PHPCS">
+    <description>VIP Go Indicator PHPCS</description>
+
+    <config name="severity" value="1" />
+
+    <arg value="sp"/> <!-- Show sniff and progress -->
+    <arg name="colors"/> <!-- Show results with colors. Disable if working on Windows -->
+    <arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
+    <arg name="parallel" value="8"/> <!-- Enables parallel processing when available for faster results -->
+    <arg name="extensions" value="php,js"/> <!-- Limit to PHP and JS files -->
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <rule ref="WordPress-VIP-Go" />
+</ruleset>


### PR DESCRIPTION
As it's specifically aimed at VIP Go, seems to make sense to check it's
meeting VIP Go standards so it can be deployed without issue.